### PR TITLE
Added support for lowercaseing outputted property names

### DIFF
--- a/src/LitJson/JsonWriter.cs
+++ b/src/LitJson/JsonWriter.cs
@@ -50,6 +50,7 @@ namespace LitJson
         private StringBuilder        inst_string_builder;
         private bool                 pretty_print;
         private bool                 validate;
+        private bool                 lower_case_properties;
         private TextWriter           writer;
         #endregion
 
@@ -75,6 +76,11 @@ namespace LitJson
         public bool Validate {
             get { return validate; }
             set { validate = value; }
+        }
+
+        public bool LowerCaseProperties {
+            get { return lower_case_properties; }
+            set { lower_case_properties = value; }
         }
         #endregion
 
@@ -166,6 +172,7 @@ namespace LitJson
             indent_value = 4;
             pretty_print = false;
             validate = true;
+            lower_case_properties = false;
 
             ctx_stack = new Stack<WriterContext> ();
             context = new WriterContext ();
@@ -442,14 +449,17 @@ namespace LitJson
         {
             DoValidation (Condition.Property);
             PutNewline ();
+            string propertyName = (property_name == null || !lower_case_properties)
+                ? property_name
+                : property_name.ToLowerInvariant();
 
-            PutString (property_name);
+            PutString (propertyName);
 
             if (pretty_print) {
-                if (property_name.Length > context.Padding)
-                    context.Padding = property_name.Length;
+                if (propertyName.Length > context.Padding)
+                    context.Padding = propertyName.Length;
 
-                for (int i = context.Padding - property_name.Length;
+                for (int i = context.Padding - propertyName.Length;
                      i >= 0; i--)
                     writer.Write (' ');
 


### PR DESCRIPTION
This enables optionally lowercasing property names in outputted JSON, example usage:

``` csharp
        private static string ToJson(object obj)
        {
            var jsonWriter = new JsonWriter {LowerCaseProperties = true};
            JsonMapper.ToJson(obj, jsonWriter);
            return jsonWriter.ToString();
        }
```
